### PR TITLE
Refactor auth persistence handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,11 +7,9 @@ import { Sidebar } from "./scenes/global/Sidebar";
 import Team from "./scenes/team";
 import Contacts from "./scenes/contacts";
 import Invoices from "./scenes/invoices";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { ProtectedRoute, PublicRoute } from "./routes";
 import { Login } from "./scenes/login";
-import { useEffect } from "react";
-import { login } from "./store/auth";
 import { Persons } from "./scenes/persons";
 import { Catalogos } from "./scenes/catalogos";
 
@@ -20,18 +18,6 @@ function App() {
   const [theme, colorMode] = useMode();
   const status = useSelector((state) => state.auth.status);
   const isAuthenticated = status === "authenticated";
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    const persistedState = localStorage.getItem("authState");
-    if (persistedState) {
-      const parsedState = JSON.parse(persistedState);
-
-      if (parsedState.status === "authenticated" && status !== "authenticated") {
-        dispatch(login(parsedState));
-      }
-    }
-  }, [dispatch, status]);
 
 
 

--- a/src/store/README.md
+++ b/src/store/README.md
@@ -1,0 +1,47 @@
+# Persistencia del estado de autenticación
+
+Este módulo centraliza la sincronización del estado de autenticación de Redux con `localStorage`.
+
+## Flujo general
+
+1. `loadAuthState` (ver [`persistence.js`](./persistence.js)) intenta cargar `authState` desde `localStorage` cuando se crea la store.
+   - Si el estado está ausente o el token expiró, se devuelve `undefined` y se limpia la entrada persistida.
+2. `store.js` usa ese resultado como `preloadedState` de `auth`, combinándolo con los valores por defecto del _slice_.
+3. El _listener middleware_ definido en `store.js` observa cualquier cambio en `state.auth`.
+4. Después de cada cambio válido, `persistAuthState` decide si debe persistir el estado (solo cuando la sesión está autenticada y el token sigue vigente) o limpiar la clave.
+
+## Hidratación inicial (`loadAuthState`)
+
+- Opera únicamente cuando `localStorage` está disponible (evita fallos durante pruebas o _server-side rendering_).
+- Normaliza la sesión devolviendo `undefined` cuando el token haya caducado, lo cual provoca que la store parta del estado por defecto.
+- El middleware se encarga de mantener la persistencia actualizada, por lo que `authSlice` ya no interactúa directamente con `localStorage`.
+
+## Sincronización con `localStorage`
+
+- El listener se suscribe a cualquier acción que modifique `auth` (incluyendo `login`, `logout` y `checkTokenExpiration`).
+- Si la sesión está autenticada y el token es válido, se guarda un `JSON` de `auth` bajo la clave `authState`.
+- Si la sesión pasa a no autenticada o el token caduca, se elimina la clave para evitar rehidrataciones inválidas.
+
+## Pruebas manuales
+
+### Persistencia tras recargar
+
+1. Inicia la aplicación (`npm run dev`) e inicia sesión con credenciales válidas.
+2. Abre las herramientas de desarrollador del navegador y confirma que existe la clave `authState` en `Application → Local Storage`.
+3. Recarga la página. La aplicación debe continuar autenticada y la clave debe mantenerse intacta.
+
+### Expiración del token
+
+1. Con la sesión iniciada, abre la consola del navegador.
+2. Ejecuta el siguiente script para forzar la caducidad inmediata del token persistido:
+
+   ```js
+   const auth = JSON.parse(localStorage.getItem('authState'));
+   auth.expiration = Date.now() - 1000;
+   localStorage.setItem('authState', JSON.stringify(auth));
+   ```
+
+3. Recarga la página. La aplicación debe iniciar en estado no autenticado y la clave `authState` debe desaparecer.
+
+> **Nota:** También puedes verificar que cerrar sesión desde la interfaz limpia `localStorage` automáticamente.
+

--- a/src/store/auth/authSlice.js
+++ b/src/store/auth/authSlice.js
@@ -1,37 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-// Cargar el estado inicial desde localStorage
-const loadState = () => {
-  try {
-    const serializedState = localStorage.getItem('authState');
-    if (serializedState === null) {
-      return undefined;
-    }
-    const state = JSON.parse(serializedState);
-
-    // Validar si el token ha expirado
-    if (state.expiration && new Date().getTime() > state.expiration) {
-      localStorage.removeItem('authState');
-      return undefined;
-    }
-
-    return state;
-  } catch (err) {
-    return undefined;
-  }
-};
-
-// Guardar el estado en localStorage
-const saveState = (state) => {
-  try {
-    const serializedState = JSON.stringify(state);
-    localStorage.setItem('authState', serializedState);
-  } catch (err) {
-    console.error('Error al guardar el estado:', err);
-  }
-};
-
-const initialState = loadState() || {
+const initialState = {
   status: 'unauthenticated',
   userId: null,
   email: null,
@@ -59,8 +28,6 @@ export const authSlice = createSlice({
       // Calcular la fecha de expiración del token (en milisegundos)
       state.expiration = new Date().getTime() + expirationDuration * 1000;
 
-      // Guardar el estado en localStorage
-      saveState(state);
     },
     logout: (state) => {
       state.status = 'unauthenticated';
@@ -70,9 +37,6 @@ export const authSlice = createSlice({
       state.photoURL = null;
       state.authToken = null;
       state.expiration = null;
-
-      // Limpiar el estado en localStorage
-      localStorage.removeItem('authState');
     },
     checkingCredentials: (state) => {
       state.status = 'checking';

--- a/src/store/persistence.js
+++ b/src/store/persistence.js
@@ -1,0 +1,70 @@
+const AUTH_STORAGE_KEY = 'authState';
+
+const getStorage = () => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage;
+  }
+
+  if (typeof localStorage !== 'undefined') {
+    return localStorage;
+  }
+
+  return null;
+};
+
+const shouldPersistAuthState = (authState) =>
+  authState && authState.status === 'authenticated' && authState.authToken;
+
+export const loadAuthState = () => {
+  const storage = getStorage();
+
+  if (!storage) {
+    return undefined;
+  }
+
+  try {
+    const serializedState = storage.getItem(AUTH_STORAGE_KEY);
+
+    if (!serializedState) {
+      return undefined;
+    }
+
+    const parsedState = JSON.parse(serializedState);
+
+    if (parsedState.expiration && Date.now() > parsedState.expiration) {
+      storage.removeItem(AUTH_STORAGE_KEY);
+      return undefined;
+    }
+
+    return parsedState;
+  } catch (error) {
+    console.warn('No se pudo cargar el estado de autenticación desde localStorage.', error);
+    return undefined;
+  }
+};
+
+export const persistAuthState = (authState) => {
+  const storage = getStorage();
+
+  if (!storage) {
+    return;
+  }
+
+  try {
+    if (!shouldPersistAuthState(authState)) {
+      storage.removeItem(AUTH_STORAGE_KEY);
+      return;
+    }
+
+    if (authState.expiration && Date.now() > authState.expiration) {
+      storage.removeItem(AUTH_STORAGE_KEY);
+      return;
+    }
+
+    const serializedState = JSON.stringify(authState);
+    storage.setItem(AUTH_STORAGE_KEY, serializedState);
+  } catch (error) {
+    console.warn('No se pudo persistir el estado de autenticación en localStorage.', error);
+  }
+};
+

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,6 +1,22 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, createListenerMiddleware } from '@reduxjs/toolkit';
 import { authSlice } from './auth';
 import { catalogoApi, contenidoCatalogoApi, formFieldApi, personasApi } from './api';
+import { loadAuthState, persistAuthState } from './persistence';
+
+const authPersistenceListener = createListenerMiddleware();
+
+authPersistenceListener.startListening({
+  predicate: (action, currentState, previousState) => currentState?.auth !== previousState?.auth,
+  effect: (_, listenerApi) => {
+    const { auth } = listenerApi.getState();
+    persistAuthState(auth);
+  },
+});
+
+const preloadedAuthState = loadAuthState();
+const preloadedState = preloadedAuthState
+  ? { auth: { ...authSlice.getInitialState(), ...preloadedAuthState } }
+  : undefined;
 
 export const store = configureStore({
   reducer: {
@@ -11,11 +27,14 @@ export const store = configureStore({
     [personasApi.reducerPath]: personasApi.reducer
   },
 
-  middleware: (getDefaultMiddleware) => 
-    getDefaultMiddleware().concat(
-    catalogoApi.middleware, 
-    contenidoCatalogoApi.middleware, 
-    formFieldApi.middleware,
-    personasApi.middleware
-  ),
+  preloadedState,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware()
+      .prepend(authPersistenceListener.middleware)
+      .concat(
+        catalogoApi.middleware,
+        contenidoCatalogoApi.middleware,
+        formFieldApi.middleware,
+        personasApi.middleware
+      ),
 });


### PR DESCRIPTION
## Summary
- centralize auth persistence logic in a dedicated persistence helper and listener middleware
- remove direct localStorage access from the auth slice and App component while preloading state from storage
- document the persistence flow and provide manual verification steps for reload persistence and token expiration

## Testing
- ❌ `npm run lint` *(fails due to pre-existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ca6b68dc832fad9ffd0ba22283c4